### PR TITLE
Un-optimize inline functions

### DIFF
--- a/bitset.c
+++ b/bitset.c
@@ -29,3 +29,114 @@ void bitset__destroy(struct bitset *s)
 	free(s->bitmap);
 	s->bitmap = NULL;
 }
+
+bool bitset__check(struct bitset *s, u32 i)
+{
+	assert(i < s->num);
+	return (s->bitmap[i / HERCULES_BITSET_WORD_BITS]) & (1u << i % HERCULES_BITSET_WORD_BITS);
+}
+
+// set bit at index i in bitmap.
+// Returns the previous state of the bit.
+bool bitset__set_mt_safe(struct bitset *s, u32 i)
+{
+	pthread_spin_lock(&s->lock);
+	libbpf_smp_rmb();
+	unsigned int bit = 1u << i % HERCULES_BITSET_WORD_BITS;
+	unsigned int prev = atomic_fetch_or(&s->bitmap[i / HERCULES_BITSET_WORD_BITS], bit);
+	if(!(prev & bit)) {
+		atomic_fetch_add(&s->num_set, 1);
+		u32 tmp_max = atomic_load(&s->max_set);
+		while(tmp_max < i) {
+			if(atomic_compare_exchange_weak(&s->max_set, &tmp_max, i)) {
+				pthread_spin_unlock(&s->lock);
+				return false;
+			}
+		}
+		pthread_spin_unlock(&s->lock);
+		return false;
+	}
+	libbpf_smp_wmb();
+	pthread_spin_unlock(&s->lock);
+	return true;
+}
+
+// set bit at index i in bitmap.
+// This function is not thread-safe.
+bool bitset__set(struct bitset *s, u32 i)
+{
+	const bool prev = bitset__check(s, i);
+	s->bitmap[i / HERCULES_BITSET_WORD_BITS] |= (1 << i % HERCULES_BITSET_WORD_BITS);
+	if(!prev) {
+		s->num_set++;
+		if(s->max_set < i) {
+			s->max_set = i;
+		}
+	}
+	return prev;
+}
+
+// unset bit at index i in bitmap.
+// Returns the previous state of the bit.
+bool bitset__unset(struct bitset *s, u32 i)
+{
+	const bool prev = bitset__check(s, i);
+	s->bitmap[i / HERCULES_BITSET_WORD_BITS] &= ~(1u << i % HERCULES_BITSET_WORD_BITS);
+	if(prev) {
+		s->num_set--;
+	}
+	return prev;
+}
+
+// Reset the bitmap
+// Unsets all entries in bitmap and reset the number of elements in the set
+void bitset__reset(struct bitset *s)
+{
+	// due to rounding, need to use the same formula as for allocation
+	memset(s->bitmap, 0,
+	       ((s->num + HERCULES_BITSET_WORD_BITS - 1) / HERCULES_BITSET_WORD_BITS) * (HERCULES_BITSET_WORD_BITS / 8));
+	s->num_set = 0;
+}
+
+// Find next entry in the set.
+// Returns lowest index i greater or equal than pos such that bit i is set, or
+// s->num if no such index exists.
+u32 bitset__scan(struct bitset *s, u32 pos)
+{
+	// TODO: profile the entire application and rewrite this function to use bitscan ops
+	for(u32 i = pos; i < s->max_set; ++i) {
+		if(bitset__check(s, i)) {
+			return i;
+		}
+	}
+	return s->num;
+}
+
+// Find next entry NOT in the set.
+// Returns lowest index i greater or equal than pos such that bit i is NOT set,
+// or s->num if no such index exists.
+u32 bitset__scan_neg(struct bitset *s, u32 pos)
+{
+	for(u32 i = pos; i < s->num; ++i) {
+		if(!bitset__check(s, i)) {
+			return i;
+		}
+	}
+	return s->num;
+}
+
+// Find nth entry NOT in the set.
+// Returns nth lowest index i greater or equal than pos such that bit i is NOT set,
+// or s->num if no such index exists.
+u32 bitset__scan_neg_n(struct bitset *s, u32 pos, u32 n)
+{
+	for(u32 i = pos; i < s->num; ++i) {
+		if(!bitset__check(s, i)) {
+			n--;
+		}
+		if(n == 0) {
+			return i;
+		}
+	}
+	return s->num;
+}

--- a/bitset.h
+++ b/bitset.h
@@ -39,116 +39,37 @@ void bitset__create(struct bitset *s, u32 num);
 void bitset__destroy(struct bitset *s);
 
 // Returns true iff the bit at index i in bitmap is set
-inline bool bitset__check(struct bitset *s, u32 i)
-{
-	assert(i < s->num);
-	return (s->bitmap[i / HERCULES_BITSET_WORD_BITS]) & (1u << i % HERCULES_BITSET_WORD_BITS);
-}
+bool bitset__check(struct bitset *s, u32 i);
 
 // set bit at index i in bitmap.
 // Returns the previous state of the bit.
-inline bool bitset__set_mt_safe(struct bitset *s, u32 i)
-{
-	pthread_spin_lock(&s->lock);
-	libbpf_smp_rmb();
-	unsigned int bit = 1u << i % HERCULES_BITSET_WORD_BITS;
-	unsigned int prev = atomic_fetch_or(&s->bitmap[i / HERCULES_BITSET_WORD_BITS], bit);
-	if(!(prev & bit)) {
-		atomic_fetch_add(&s->num_set, 1);
-		u32 tmp_max = atomic_load(&s->max_set);
-		while(tmp_max < i) {
-			if(atomic_compare_exchange_weak(&s->max_set, &tmp_max, i)) {
-				pthread_spin_unlock(&s->lock);
-				return false;
-			}
-		}
-		pthread_spin_unlock(&s->lock);
-		return false;
-	}
-	libbpf_smp_wmb();
-	pthread_spin_unlock(&s->lock);
-	return true;
-}
+bool bitset__set_mt_safe(struct bitset *s, u32 i);
 
 // set bit at index i in bitmap.
 // This function is not thread-safe.
-inline bool bitset__set(struct bitset *s, u32 i)
-{
-	const bool prev = bitset__check(s, i);
-	s->bitmap[i / HERCULES_BITSET_WORD_BITS] |= (1 << i % HERCULES_BITSET_WORD_BITS);
-	if(!prev) {
-		s->num_set++;
-		if(s->max_set < i) {
-			s->max_set = i;
-		}
-	}
-	return prev;
-}
-
+bool bitset__set(struct bitset *s, u32 i);
 
 // unset bit at index i in bitmap.
 // Returns the previous state of the bit.
-inline bool bitset__unset(struct bitset *s, u32 i)
-{
-	const bool prev = bitset__check(s, i);
-	s->bitmap[i / HERCULES_BITSET_WORD_BITS] &= ~(1u << i % HERCULES_BITSET_WORD_BITS);
-	if(prev) {
-		s->num_set--;
-	}
-	return prev;
-}
+bool bitset__unset(struct bitset *s, u32 i);
 
 // Reset the bitmap
 // Unsets all entries in bitmap and reset the number of elements in the set
-inline void bitset__reset(struct bitset *s)
-{
-	// due to rounding, need to use the same formula as for allocation
-	memset(s->bitmap, 0,
-	       ((s->num + HERCULES_BITSET_WORD_BITS - 1) / HERCULES_BITSET_WORD_BITS) * (HERCULES_BITSET_WORD_BITS / 8));
-	s->num_set = 0;
-}
+void bitset__reset(struct bitset *s);
 
 // Find next entry in the set.
 // Returns lowest index i greater or equal than pos such that bit i is set, or
 // s->num if no such index exists.
-inline u32 bitset__scan(struct bitset *s, u32 pos)
-{
-	// TODO: profile the entire application and rewrite this function to use bitscan ops
-	for(u32 i = pos; i < s->max_set; ++i) {
-		if(bitset__check(s, i)) {
-			return i;
-		}
-	}
-	return s->num;
-}
+u32 bitset__scan(struct bitset *s, u32 pos);
 
 // Find next entry NOT in the set.
 // Returns lowest index i greater or equal than pos such that bit i is NOT set,
 // or s->num if no such index exists.
-inline u32 bitset__scan_neg(struct bitset *s, u32 pos)
-{
-	for(u32 i = pos; i < s->num; ++i) {
-		if(!bitset__check(s, i)) {
-			return i;
-		}
-	}
-	return s->num;
-}
+u32 bitset__scan_neg(struct bitset *s, u32 pos);
 
 // Find nth entry NOT in the set.
 // Returns nth lowest index i greater or equal than pos such that bit i is NOT set,
 // or s->num if no such index exists.
-inline u32 bitset__scan_neg_n(struct bitset *s, u32 pos, u32 n)
-{
-	for(u32 i = pos; i < s->num; ++i) {
-		if(!bitset__check(s, i)) {
-			n--;
-		}
-		if(n == 0) {
-			return i;
-		}
-	}
-	return s->num;
-}
+u32 bitset__scan_neg_n(struct bitset *s, u32 pos, u32 n);
 
 #endif // __HERCULES_BITSET_H__

--- a/congestion_control.c
+++ b/congestion_control.c
@@ -147,7 +147,7 @@ static u32 pcc_control_startup(struct ccontrol_state *cc_state, float utility, f
 	}
 }
 
-static inline u32 calculate_rate(double mi_duration, u32 prev_rate, float factor) {
+static u32 calculate_rate(double mi_duration, u32 prev_rate, float factor) {
 	u32 new_rate = prev_rate * factor;
 	if(factor < 1) {
 		if((u32) (new_rate * mi_duration) > (u32) (prev_rate * mi_duration) - 10) {

--- a/cutils.go
+++ b/cutils.go
@@ -14,9 +14,9 @@
 
 package main
 
-// #cgo CFLAGS: -O3 -Wall -DNDEBUG -D_GNU_SOURCE -march=sandybridge -mtune=broadwell
+// #cgo CFLAGS: -O1 -Wall -DNDEBUG -D_GNU_SOURCE
 // #cgo LDFLAGS: ${SRCDIR}/bpf/src/libbpf.a -lm -lelf -pthread -lz
-// #pragma GCC diagnostic ignored "-Wunused-variable" // Hide warning in cgo-gcc-prolog
+// #pragma GCC diagnostic ignored "-Wunused-variable"
 // #include "hercules.h"
 // #include <linux/if_xdp.h>
 // #include <stdint.h>

--- a/frame_queue.h
+++ b/frame_queue.h
@@ -26,7 +26,7 @@ struct frame_queue {
 	u16 index_mask;
 };
 
-inline int frame_queue__init(struct frame_queue *fq, u16 size)
+int frame_queue__init(struct frame_queue *fq, u16 size)
 {
 	if((size == 0) || ((size & (size - 1)) != 0)) {
 		return EINVAL; // size is zero or not a power of two
@@ -41,32 +41,32 @@ inline int frame_queue__init(struct frame_queue *fq, u16 size)
 	return EXIT_SUCCESS;
 }
 
-inline u16 frame_queue__prod_reserve(struct frame_queue *fq, u16 num)
+u16 frame_queue__prod_reserve(struct frame_queue *fq, u16 num)
 {
 	return umin16(atomic_load(&fq->cons) - fq->prod, num);
 }
 
-inline void frame_queue__prod_fill(struct frame_queue *fq, u16 offset, u64 addr)
+void frame_queue__prod_fill(struct frame_queue *fq, u16 offset, u64 addr)
 {
 	fq->addrs[(fq->prod + offset) & fq->index_mask] = addr >> XSK_UMEM__DEFAULT_FRAME_SHIFT;
 }
 
-inline void frame_queue__push(struct frame_queue *fq, u16 num)
+void frame_queue__push(struct frame_queue *fq, u16 num)
 {
 	atomic_fetch_add(&fq->prod, num);
 }
 
-inline u16 frame_queue__cons_reserve(struct frame_queue *fq, u16 num)
+u16 frame_queue__cons_reserve(struct frame_queue *fq, u16 num)
 {
 	return umin16(atomic_load(&fq->prod) - fq->cons + fq->size, num);
 }
 
-inline u64 frame_queue__cons_fetch(struct frame_queue *fq, u16 offset)
+u64 frame_queue__cons_fetch(struct frame_queue *fq, u16 offset)
 {
 	return fq->addrs[(fq->cons + offset) & fq->index_mask] << XSK_UMEM__DEFAULT_FRAME_SHIFT;
 }
 
-inline void frame_queue__pop(struct frame_queue *fq, u16 num)
+void frame_queue__pop(struct frame_queue *fq, u16 num)
 {
 	atomic_fetch_add(&fq->cons, num);
 }

--- a/hercules.c
+++ b/hercules.c
@@ -305,7 +305,7 @@ static void close_xsk(struct xsk_socket_info *xsk)
 	free(xsk);
 }
 
-static inline struct hercules_interface *get_interface_by_id(struct hercules_session *session, int ifid)
+static struct hercules_interface *get_interface_by_id(struct hercules_session *session, int ifid)
 {
 	for(int i = 0; i < session->num_ifaces; i++) {
 		if(session->ifaces[i].ifid == ifid) {
@@ -812,7 +812,7 @@ static void pop_completion_ring(struct hercules_session *session, struct xsk_ume
 	}
 }
 
-static inline void pop_completion_rings(struct hercules_session *session)
+static void pop_completion_rings(struct hercules_session *session)
 {
 	for(int i = 0; i < session->num_ifaces; i++) {
 		pop_completion_ring(session, session->ifaces[i].umem);
@@ -1384,7 +1384,7 @@ static void rx_handle_initial(struct receiver_state *rx_state, struct rbudp_init
 static void
 submit_rx_frames(struct hercules_session *session, struct xsk_umem_info *umem, const u64 *addrs, size_t num_frames)
 {
-	u32 idx_fq;
+	u32 idx_fq = 0;
 	pthread_spin_lock(&umem->lock);
 	size_t reserved = xsk_ring_prod__reserve(&umem->fq, num_frames, &idx_fq);
 	while(reserved != num_frames) {
@@ -1624,7 +1624,7 @@ static char *prepare_frame(struct xsk_socket_info *xsk, u64 addr, u32 prod_tx_id
 static short flowIdCtr = 0;
 #endif
 
-static inline void tx_handle_send_queue_unit_for_iface(struct sender_state *tx_state, struct xsk_socket_info *xsk,
+static void tx_handle_send_queue_unit_for_iface(struct sender_state *tx_state, struct xsk_socket_info *xsk,
 													   int ifid, u64 frame_addrs[SEND_QUEUE_ENTRIES_PER_UNIT],
 													   struct send_queue_unit *unit)
 {
@@ -1683,7 +1683,7 @@ static inline void tx_handle_send_queue_unit_for_iface(struct sender_state *tx_s
 	xsk_ring_prod__submit(&xsk->tx, num_chunks_in_unit);
 }
 
-static inline void tx_handle_send_queue_unit(struct sender_state *tx_state, struct xsk_socket_info *xsks[],
+static void tx_handle_send_queue_unit(struct sender_state *tx_state, struct xsk_socket_info *xsks[],
 											 u64 frame_addrs[][SEND_QUEUE_ENTRIES_PER_UNIT],
 											 struct send_queue_unit *unit)
 {
@@ -1728,7 +1728,7 @@ produce_batch(struct sender_state *tx_state, const u8 *path_by_rcvr, const u32 *
 	}
 }
 
-static inline void allocate_tx_frames(struct hercules_session *session,
+static void allocate_tx_frames(struct hercules_session *session,
 									  u64 frame_addrs[][SEND_QUEUE_ENTRIES_PER_UNIT])
 {
 	for(int i = 0; i < session->num_ifaces; i++) {
@@ -1920,7 +1920,7 @@ static u32 prepare_rcvr_chunks(struct sender_state *tx_state, u32 rcvr_idx, u32 
 	return num_chunks_prepared;
 }
 
-inline bool pcc_has_active_mi(struct ccontrol_state *cc_state, u64 now)
+bool pcc_has_active_mi(struct ccontrol_state *cc_state, u64 now)
 {
 	return cc_state->state != pcc_terminated &&
 	       cc_state->state != pcc_uninitialized &&

--- a/linux/bpf_util.h
+++ b/linux/bpf_util.h
@@ -8,36 +8,6 @@
 #include <string.h>
 #include <errno.h>
 
-static inline unsigned int bpf_num_possible_cpus(void)
-{
-	static const char *fcpu = "/sys/devices/system/cpu/possible";
-	unsigned int start, end, possible_cpus = 0;
-	char buff[128];
-	FILE *fp;
-	int n;
-
-	fp = fopen(fcpu, "r");
-	if (!fp) {
-		printf("Failed to open %s: '%s'!\n", fcpu, strerror(errno));
-		exit(1);
-	}
-
-	while (fgets(buff, sizeof(buff), fp)) {
-		n = sscanf(buff, "%u-%u", &start, &end);
-		if (n == 0) {
-			printf("Failed to retrieve # possible CPUs!\n");
-			exit(1);
-		} else if (n == 1) {
-			end = start;
-		}
-		possible_cpus = start == 0 ? end + 1 : 0;
-		break;
-	}
-	fclose(fp);
-
-	return possible_cpus;
-}
-
 #define __bpf_percpu_val_align	__attribute__((__aligned__(8)))
 
 #define BPF_DECLARE_PERCPU(type, name)				\

--- a/utils.c
+++ b/utils.c
@@ -1,0 +1,67 @@
+// Copyright 2019 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "utils.h"
+
+u16 umin16(u16 a, u16 b)
+{
+	return (a < b) ? a : b;
+}
+
+u16 umax16(u16 a, u16 b)
+{
+	return (a > b) ? a : b;
+}
+
+u32 umin32(u32 a, u32 b)
+{
+	return (a < b) ? a : b;
+}
+
+u32 umax32(u32 a, u32 b)
+{
+	return (a > b) ? a : b;
+}
+
+u64 umin64(u64 a, u64 b)
+{
+	return (a < b) ? a : b;
+}
+
+u64 umax64(u64 a, u64 b)
+{
+	return (a > b) ? a : b;
+}
+
+u64 get_nsecs(void)
+{
+	struct timespec ts;
+
+	clock_gettime(CLOCK_MONOTONIC, &ts);
+	return ts.tv_sec * 1000000000UL + ts.tv_nsec;
+}
+
+void sleep_until(u64 ns)
+{
+	struct timespec req;
+	req.tv_sec = (time_t)(ns / 1000000000UL);
+	req.tv_nsec = (long)(ns % 1000000000UL);
+	clock_nanosleep(CLOCK_MONOTONIC, TIMER_ABSTIME, &req, NULL);
+}
+
+void sleep_nsecs(u64 ns)
+{
+	// Use clock_nanosleep to avoid drift by repeated interrupts. See NOTES in man(2) nanosleep.
+	sleep_until(get_nsecs() + ns);
+}

--- a/utils.h
+++ b/utils.h
@@ -35,58 +35,18 @@ typedef __u8 u8;
 # define likely(x)              __builtin_expect(!!(x), 1)
 #endif
 
-inline u16 umin16(u16 a, u16 b)
-{
-	return (a < b) ? a : b;
-}
+u16 umin16(u16 a, u16 b);
+u16 umax16(u16 a, u16 b);
 
-inline u16 umax16(u16 a, u16 b)
-{
-	return (a > b) ? a : b;
-}
+u32 umin32(u32 a, u32 b);
+u32 umax32(u32 a, u32 b);
 
-inline u32 umin32(u32 a, u32 b)
-{
-	return (a < b) ? a : b;
-}
+u64 umin64(u64 a, u64 b);
+u64 umax64(u64 a, u64 b);
 
-inline u32 umax32(u32 a, u32 b)
-{
-	return (a > b) ? a : b;
-}
+u64 get_nsecs(void);
 
-inline u64 umin64(u64 a, u64 b)
-{
-	return (a < b) ? a : b;
-}
-
-inline u64 umax64(u64 a, u64 b)
-{
-	return (a > b) ? a : b;
-}
-
-
-inline u64 get_nsecs(void)
-{
-	struct timespec ts;
-
-	clock_gettime(CLOCK_MONOTONIC, &ts);
-	return ts.tv_sec * 1000000000UL + ts.tv_nsec;
-}
-
-inline void sleep_until(u64 ns)
-{
-	struct timespec req;
-	req.tv_sec = (time_t)(ns / 1000000000UL);
-	req.tv_nsec = (long)(ns % 1000000000UL);
-	clock_nanosleep(CLOCK_MONOTONIC, TIMER_ABSTIME, &req, NULL);
-}
-
-inline void sleep_nsecs(u64 ns)
-{
-	// Use clock_nanosleep to avoid drift by repeated interrupts. See NOTES in man(2) nanosleep.
-	sleep_until(get_nsecs() + ns);
-}
-
+void sleep_until(u64 ns);
+void sleep_nsecs(u64 ns);
 
 #endif


### PR DESCRIPTION
With the updated toolchain, inline functions result in segfaults. As a first fix, we therefore un-optimize all inline functions. Later on, these optimizations can be cautiously reintroduced, if necessary.